### PR TITLE
fix CI: add ci-build --finish step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,9 @@ jobs:
     - run:
         name: Run Toolkit Build
         command: npx grafana-toolkit plugin:ci-build
+    - run:
+        name: Move Build Result to Ci Folder
+        command: npx grafana-toolkit plugin:ci-build --finish
     - save_cache:
         paths:
         - node_modules


### PR DESCRIPTION
Fixes CI (hopefully), `ci-build --finish` step was missing. 
Targeting Andy's PR which fixes lint problem that was also blocking the build