### PR TITLE
Replace font-awesome with Unicons

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -19,13 +19,13 @@ export const plugin = new AppPlugin<ExampleAppSettings>()
   .setRootPage((ExampleRootPage as unknown) as ComponentClass<AppRootProps>)
   .addConfigPage({
     title: 'Page 1',
-    icon: 'fa fa-info',
+    icon: 'info-circle',
     body: ExamplePage1,
     id: 'page1',
   })
   .addConfigPage({
     title: 'Page 2',
-    icon: 'fa fa-user',
+    icon: 'user',
     body: ExamplePage2,
     id: 'page2',
   });

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -13,19 +13,19 @@ export type PageDefinition = {
 export const pages: PageDefinition[] = [
   {
     component: A,
-    icon: 'fa fa-fw fa-file-text-o',
+    icon: 'file-alt',
     id: 'a',
     text: 'Tab A',
   },
   {
     component: B,
-    icon: 'fa fa-fw fa-file-text-o',
+    icon: 'file-alt',
     id: 'b',
     text: 'Tab B',
   },
   {
     component: C,
-    icon: 'fa fa-fw fa-file-text-o',
+    icon: 'file-alt',
     id: 'c',
     text: 'Tab C',
   },

--- a/src/utils/consts.ts
+++ b/src/utils/consts.ts
@@ -1,2 +1,2 @@
-export const APP_TITLE = 'Grafana Cloud Alerting';
-export const APP_SUBTITLE = 'Manage rules & notifications';
+export const APP_TITLE = 'Simple App Plugin';
+export const APP_SUBTITLE = 'Simple App Plugin subtitle';


### PR DESCRIPTION
Since font-awesome is deprecated and will be removed next mayor release: https://github.com/grafana/alerting-ui-plugin/pull/191#issue-511470349, removed the icons here as well.