### PR TITLE
README: add deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+
+## ⚠️ Deprecated!
+
+**This repository is deprecated.** <br />
+A more up-to-date version is available here: https://github.com/grafana/grafana-plugin-examples/tree/master/examples/app-basic
+
+---
+
 # Grafana App Plugin Template
 
 [![Build](https://github.com/grafana/grafana-starter-app/workflows/CI/badge.svg)](https://github.com/grafana/grafana-starter-app/actions?query=workflow%3A%22CI%22)


### PR DESCRIPTION
### What changed?
Added a deprecation notice to the README and linked the new `grafana/grafana-plugin-examples` repo as the place to go to.

[Check out the updated README](https://github.com/grafana/grafana-starter-app/blob/leventebalogh/add-deprecation-notice/README.md)